### PR TITLE
Add: XLSX import script for last year's data (DB-only)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^4.21.2",
         "googleapis": "^171.4.0",
         "postgres": "^3.4.9",
+        "xlsx": "^0.18.5",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -2191,6 +2192,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2648,6 +2658,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2722,6 +2745,15 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -2846,6 +2878,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/create-jest": {
@@ -4085,6 +4129,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fresh": {
@@ -6423,6 +6476,18 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -6974,6 +7039,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -7018,6 +7101,27 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/y18n": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,8 @@
     "test": "jest",
     "test:ci": "jest --runInBand",
     "db:push": "drizzle-kit push",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "import:2025": "tsx scripts/import-2025.ts"
   },
   "keywords": [],
   "author": "",
@@ -24,6 +25,7 @@
     "express": "^4.21.2",
     "googleapis": "^171.4.0",
     "postgres": "^3.4.9",
+    "xlsx": "^0.18.5",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/backend/scripts/import-2025.ts
+++ b/backend/scripts/import-2025.ts
@@ -1,0 +1,73 @@
+import 'dotenv/config';
+import path from 'path';
+import * as XLSX from 'xlsx';
+import { and, eq } from 'drizzle-orm';
+import { db } from '../src/db/client';
+import { campers } from '../src/db/schema';
+import { mapCamperRow, IMPORT_2025_SOURCE } from '../src/lib/import-mapper';
+
+const TARGET_YEAR = 2025;
+const SHEET_NAME = 'Campers';
+
+const filePath =
+  process.argv[2] ?? path.resolve(__dirname, '../../assets/Power Camp Admin 2025.xlsx');
+
+async function main() {
+  console.log(`Reading ${filePath}…`);
+  const wb = XLSX.readFile(filePath, { cellDates: true });
+  const sheet = wb.Sheets[SHEET_NAME];
+  if (!sheet) {
+    throw new Error(`Sheet '${SHEET_NAME}' not found. Sheets: ${wb.SheetNames.join(', ')}`);
+  }
+
+  const rows = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet, { defval: '' });
+  console.log(`Read ${rows.length} data rows from '${SHEET_NAME}'.`);
+
+  const inserts: (typeof campers.$inferInsert)[] = [];
+  const skipped: { row: number; reason: string }[] = [];
+
+  rows.forEach((row, i) => {
+    const result = mapCamperRow(row, TARGET_YEAR);
+    if (result.skip) {
+      skipped.push({ row: i + 2, reason: result.reason });
+    } else {
+      inserts.push(result.value);
+    }
+  });
+
+  console.log(`Mapping result: ${inserts.length} importable, ${skipped.length} skipped.`);
+  if (skipped.length > 0) {
+    console.log('Skipped rows:');
+    skipped.slice(0, 10).forEach((s) => console.log(`  - row ${s.row}: ${s.reason}`));
+    if (skipped.length > 10) console.log(`  … and ${skipped.length - 10} more.`);
+  }
+
+  console.log(
+    `\nClearing existing rows where year=${TARGET_YEAR} AND source='${IMPORT_2025_SOURCE}'…`
+  );
+
+  await db.transaction(async (tx) => {
+    const deleted = await tx
+      .delete(campers)
+      .where(and(eq(campers.year, TARGET_YEAR), eq(campers.source, IMPORT_2025_SOURCE)))
+      .returning({ id: campers.id });
+    console.log(`Deleted ${deleted.length} existing import rows.`);
+
+    if (inserts.length > 0) {
+      const inserted = await tx.insert(campers).values(inserts).returning({ id: campers.id });
+      console.log(`Inserted ${inserted.length} campers.`);
+    }
+  });
+
+  const uniqueParents = new Set(inserts.map((i) => i.parentEmail));
+  console.log(
+    `\n✓ Done. Imported ${inserts.length} campers (${uniqueParents.size} unique parent emails) for year ${TARGET_YEAR}.`
+  );
+
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Import failed:', err);
+  process.exit(1);
+});

--- a/backend/src/__tests__/import-mapper.test.ts
+++ b/backend/src/__tests__/import-mapper.test.ts
@@ -1,0 +1,102 @@
+import { mapCamperRow, IMPORT_2025_SOURCE } from '../lib/import-mapper';
+
+const validRow = {
+  'First Name': 'Emma',
+  'LastName': 'Cable',
+  'camperCell': 832876634,
+  'gender': 'Female',
+  'email': 'Emma.Glynis.Cable@outlook.com',
+  'age': 16,
+  'grade': 11,
+  'Friends': 'Abigail Swanepoel, Sarah Jones',
+  'medical': '',
+  'parentName': 'Jillian Cable',
+  'parentPhone': 828756784,
+  'ParentEmail': 'JILL.CABLE@me.com',
+  'church': 'Brackenhurst Baptist Church',
+  'T-shirt': 'small',
+  'General Info': '',
+  'dob': new Date('2008-09-15T00:00:00Z'),
+};
+
+describe('mapCamperRow', () => {
+  it('maps a valid row into a NewCamper insert payload tagged with year + import source', () => {
+    const result = mapCamperRow(validRow, 2025);
+    expect(result.skip).toBe(false);
+    if (result.skip) return;
+
+    expect(result.value).toMatchObject({
+      year: 2025,
+      source: IMPORT_2025_SOURCE,
+      firstName: 'Emma',
+      lastName: 'Cable',
+      gender: 'Female',
+      age: '16',
+      grade: '11',
+      church: 'Brackenhurst Baptist Church',
+      tshirt: 'small',
+    });
+  });
+
+  it('lowercases email and parentEmail', () => {
+    const result = mapCamperRow(validRow, 2025);
+    if (result.skip) throw new Error('expected mapped row');
+    expect(result.value.email).toBe('emma.glynis.cable@outlook.com');
+    expect(result.value.parentEmail).toBe('jill.cable@me.com');
+  });
+
+  it('restores leading zero on 9-digit SA phone numbers', () => {
+    const result = mapCamperRow(validRow, 2025);
+    if (result.skip) throw new Error('expected mapped row');
+    expect(result.value.camperCell).toBe('0832876634');
+    expect(result.value.parentPhone).toBe('0828756784');
+  });
+
+  it('leaves already-correct phone numbers alone', () => {
+    const result = mapCamperRow(
+      { ...validRow, camperCell: '0832876634', parentPhone: '0828756784' },
+      2025
+    );
+    if (result.skip) throw new Error('expected mapped row');
+    expect(result.value.camperCell).toBe('0832876634');
+    expect(result.value.parentPhone).toBe('0828756784');
+  });
+
+  it('converts a Date dob to YYYY-MM-DD', () => {
+    const result = mapCamperRow(validRow, 2025);
+    if (result.skip) throw new Error('expected mapped row');
+    expect(result.value.dob).toBe('2008-09-15');
+  });
+
+  it('splits the Friends cell on commas and trims whitespace', () => {
+    const result = mapCamperRow(validRow, 2025);
+    if (result.skip) throw new Error('expected mapped row');
+    expect(result.value.friends).toEqual(['Abigail Swanepoel', 'Sarah Jones']);
+  });
+
+  it('returns an empty friends array when the cell is blank', () => {
+    const result = mapCamperRow({ ...validRow, Friends: '' }, 2025);
+    if (result.skip) throw new Error('expected mapped row');
+    expect(result.value.friends).toEqual([]);
+  });
+
+  it('skips rows missing First Name', () => {
+    const result = mapCamperRow({ ...validRow, 'First Name': '' }, 2025);
+    expect(result).toEqual({ skip: true, reason: 'missing First Name' });
+  });
+
+  it('skips rows missing LastName', () => {
+    const result = mapCamperRow({ ...validRow, LastName: '' }, 2025);
+    expect(result).toEqual({ skip: true, reason: 'missing LastName' });
+  });
+
+  it('skips rows missing ParentEmail', () => {
+    const result = mapCamperRow({ ...validRow, ParentEmail: '' }, 2025);
+    expect(result).toEqual({ skip: true, reason: 'missing ParentEmail' });
+  });
+
+  it('handles whitespace-only fields as missing', () => {
+    const result = mapCamperRow({ ...validRow, 'First Name': '   ' }, 2025);
+    expect(result).toEqual({ skip: true, reason: 'missing First Name' });
+  });
+});

--- a/backend/src/lib/import-mapper.ts
+++ b/backend/src/lib/import-mapper.ts
@@ -1,0 +1,73 @@
+import type { campers } from '../db/schema';
+
+export const IMPORT_2025_SOURCE = 'import-2025';
+
+type NewCamper = typeof campers.$inferInsert;
+
+export type MapResult =
+  | { skip: false; value: NewCamper }
+  | { skip: true; reason: string };
+
+function s(v: unknown): string {
+  if (v === null || v === undefined) return '';
+  return String(v).trim();
+}
+
+// Excel stores phone numbers as numbers, dropping leading zeros.
+// SA mobile numbers are 10 digits starting with 0 — restore the leading zero.
+function phone(v: unknown): string {
+  const raw = s(v).replace(/\s+/g, '');
+  if (!raw) return '';
+  if (/^[1-9]\d{8}$/.test(raw)) return '0' + raw;
+  return raw;
+}
+
+function dobToISO(v: unknown): string {
+  if (!v) return '';
+  if (v instanceof Date && !isNaN(v.getTime())) {
+    return v.toISOString().split('T')[0];
+  }
+  return s(v);
+}
+
+function splitFriends(v: unknown): string[] {
+  const raw = s(v);
+  if (!raw) return [];
+  return raw.split(/[,;]/).map((p) => p.trim()).filter(Boolean);
+}
+
+export function mapCamperRow(row: Record<string, unknown>, year: number): MapResult {
+  const firstName = s(row['First Name']);
+  const lastName = s(row['LastName'] ?? row['Last Name']);
+  const parentEmail = s(row['ParentEmail'] ?? row['parentEmail']).toLowerCase();
+
+  if (!firstName) return { skip: true, reason: 'missing First Name' };
+  if (!lastName) return { skip: true, reason: 'missing LastName' };
+  if (!parentEmail) return { skip: true, reason: 'missing ParentEmail' };
+
+  const email = s(row['email']).toLowerCase();
+
+  return {
+    skip: false,
+    value: {
+      year,
+      source: IMPORT_2025_SOURCE,
+      firstName,
+      lastName,
+      camperCell: phone(row['camperCell']) || undefined,
+      gender: s(row['gender']) || undefined,
+      email: email || undefined,
+      age: s(row['age']) || undefined,
+      grade: s(row['grade']) || undefined,
+      friends: splitFriends(row['Friends']),
+      medical: s(row['medical']) || undefined,
+      parentName: s(row['parentName']) || undefined,
+      parentPhone: phone(row['parentPhone']) || undefined,
+      parentEmail,
+      church: s(row['church']) || undefined,
+      tshirt: s(row['T-shirt']) || undefined,
+      generalInfo: s(row['General Info']) || undefined,
+      dob: dobToISO(row['dob']) || undefined,
+    },
+  };
+}


### PR DESCRIPTION
Adds backend/scripts/import-2025.ts to load the 2025 Power Camp Admin spreadsheet into the campers table, tagged year=2025 and source='import-2025' so it co-exists with web submissions.

The script writes to the database only — never to the live Google Sheet. The sheet is reserved for the current year's registrations so the Mailchimp Apps Script trigger only ever fires on actual 2026 sign-ups.

Mapping logic lives in src/lib/import-mapper.ts as a pure function (testable without DB or filesystem). It handles:
- 9-digit phone numbers (Excel strips leading zeros) → restored
- Excel Date dob → YYYY-MM-DD
- Comma/semicolon-separated Friends → string array
- Lowercased emails (camper + parent)
- Trimmed strings; whitespace-only treated as missing
- Skips rows missing First Name / LastName / ParentEmail

The runner is idempotent: each invocation deletes only its own previous import rows (year=2025 AND source='import-2025') in a transaction before bulk-inserting, so it's safe to re-run after fixing the spreadsheet.

Run with: npm run import:2025 [path/to/file.xlsx]

11 unit tests for the mapper.