### PR TITLE
Add: name-search lookup + 2026 Intro/Details refresh

### DIFF
--- a/backend/src/__tests__/lookup.test.ts
+++ b/backend/src/__tests__/lookup.test.ts
@@ -1,0 +1,105 @@
+import express from 'express';
+import request from 'supertest';
+
+const queryMock = jest.fn();
+jest.mock('../db/client', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => ({
+            limit: () => queryMock(),
+          }),
+        }),
+      }),
+    }),
+  },
+}));
+
+import { lookupRouter, maskEmail } from '../routes/lookup';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(lookupRouter);
+  return app;
+}
+
+describe('POST /lookup', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
+  it('returns mapped results with masked parent emails on a match', async () => {
+    queryMock.mockResolvedValueOnce([
+      {
+        id: 7,
+        firstName: 'Emma',
+        lastName: 'Cable',
+        year: 2025,
+        parentEmail: 'jill.cable@me.com',
+      },
+    ]);
+
+    const res = await request(buildApp()).post('/lookup').send({ q: 'emma' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      results: [
+        {
+          id: 7,
+          firstName: 'Emma',
+          lastName: 'Cable',
+          year: 2025,
+          parentEmailMasked: 'ji***@me.com',
+        },
+      ],
+    });
+  });
+
+  it('returns an empty results array when nothing matches', async () => {
+    queryMock.mockResolvedValueOnce([]);
+
+    const res = await request(buildApp()).post('/lookup').send({ q: 'zzz' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ results: [] });
+  });
+
+  it('rejects an empty or whitespace-only query with 400', async () => {
+    const res = await request(buildApp()).post('/lookup').send({ q: '   ' });
+    expect(res.status).toBe(400);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing query body with 400', async () => {
+    const res = await request(buildApp()).post('/lookup').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 when the DB query throws', async () => {
+    queryMock.mockRejectedValueOnce(new Error('db down'));
+    const res = await request(buildApp()).post('/lookup').send({ q: 'emma' });
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Lookup failed' });
+  });
+});
+
+describe('maskEmail', () => {
+  it('masks a normal email keeping first two characters of the local part', () => {
+    expect(maskEmail('jill.cable@me.com')).toBe('ji***@me.com');
+  });
+
+  it('masks a single-character local part to its only character', () => {
+    expect(maskEmail('a@b.com')).toBe('a***@b.com');
+  });
+
+  it('returns empty string for null/undefined', () => {
+    expect(maskEmail(null)).toBe('');
+    expect(maskEmail(undefined)).toBe('');
+  });
+
+  it('returns *** for malformed emails', () => {
+    expect(maskEmail('not-an-email')).toBe('***');
+  });
+});

--- a/backend/src/routes/lookup.ts
+++ b/backend/src/routes/lookup.ts
@@ -1,0 +1,60 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { and, ilike, isNull, or, desc } from 'drizzle-orm';
+import { db } from '../db/client';
+import { campers } from '../db/schema';
+
+const lookupBody = z.object({
+  q: z.string().trim().min(1).max(100),
+});
+
+export function maskEmail(email: string | null | undefined): string {
+  if (!email) return '';
+  const [local, domain] = email.split('@');
+  if (!domain || !local) return '***';
+  const visible = local.length <= 2 ? local[0] : local.slice(0, 2);
+  return `${visible}***@${domain}`;
+}
+
+export const lookupRouter = Router();
+
+lookupRouter.post('/lookup', async (req, res) => {
+  const parsed = lookupBody.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Invalid query' });
+  }
+  const pattern = `%${parsed.data.q}%`;
+
+  try {
+    const rows = await db
+      .select({
+        id: campers.id,
+        firstName: campers.firstName,
+        lastName: campers.lastName,
+        year: campers.year,
+        parentEmail: campers.parentEmail,
+      })
+      .from(campers)
+      .where(
+        and(
+          isNull(campers.deletedAt),
+          or(ilike(campers.firstName, pattern), ilike(campers.lastName, pattern))
+        )
+      )
+      .orderBy(desc(campers.year), campers.lastName, campers.firstName)
+      .limit(50);
+
+    const results = rows.map((r) => ({
+      id: r.id,
+      firstName: r.firstName,
+      lastName: r.lastName,
+      year: r.year,
+      parentEmailMasked: maskEmail(r.parentEmail),
+    }));
+
+    res.json({ results });
+  } catch (err) {
+    console.error('Lookup error:', err);
+    res.status(500).json({ error: 'Lookup failed' });
+  }
+});

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -5,6 +5,7 @@ import { env } from './env';
 import { submitRouter } from './routes/submit';
 import { consentRouter } from './routes/consent';
 import { feedbackRouter } from './routes/feedback';
+import { lookupRouter } from './routes/lookup';
 
 const app = express();
 
@@ -21,6 +22,7 @@ app.use(express.json());
 app.use(submitRouter);
 app.use(consentRouter);
 app.use(feedbackRouter);
+app.use(lookupRouter);
 
 const distDir = path.resolve(__dirname, '../dist/powercamp/browser');
 app.use(express.static(distDir));

--- a/src/app/details/details.component.ts
+++ b/src/app/details/details.component.ts
@@ -13,10 +13,10 @@ import { StepKey } from '../../models';
       <h2 class="text-2xl font-bold mb-4 text-gray-900">Camp Details</h2>
       <div class="mb-4 text-md text-gray-700 space-y-2">
         <div>
-          <span class="font-semibold">Starts:</span> Friday 22nd August at 17:00
+          <span class="font-semibold">Starts:</span> Friday 31 July 2026 at 17:00
         </div>
         <div>
-          <span class="font-semibold">Ends:</span> Sunday 24th August at 14:00
+          <span class="font-semibold">Ends:</span> Sunday 2 August 2026 at 14:00
         </div>
         <div>
           <span class="font-semibold">Where:</span> YFC Magaliesburg (Boitumelo

--- a/src/app/form/form.component.ts
+++ b/src/app/form/form.component.ts
@@ -5,6 +5,7 @@ import { DetailsComponent } from '../details/details.component';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { FriendsComponent } from '../friends/friends.component';
 import { IntroComponent } from '../intro/intro.component';
+import { LookupComponent } from '../lookup/lookup.component';
 import { LeaderApplicationComponent } from '../leader-application/leader-application.component';
 import { LeaderInfoComponent } from '../leader-info/leader-info.component';
 import { MedicalComponent } from '../medical/medical.component';
@@ -26,6 +27,7 @@ import { environment } from '../../environments/environment';
     FormsModule,
     FriendsComponent,
     IntroComponent,
+    LookupComponent,
     LeaderApplicationComponent,
     LeaderInfoComponent,
     MedicalComponent,
@@ -60,18 +62,25 @@ import { environment } from '../../environments/environment';
             }
             <form [formGroup]="rootFormGroup">
               <div class="">
+                @if (currentStep() === StepKey.Lookup && stepVisible()) {
+                  <app-lookup
+                    [stepVisible]="stepVisible()"
+                    (goToStep)="fadeToStep($event)"
+                    (selectedCamper)="onSelectedCamper($event)"
+                  ></app-lookup>
+                }
                 @if (currentStep() === StepKey.Intro && stepVisible()) {
                   <app-intro
                     [stepVisible]="stepVisible()"
                     (goToStep)="fadeToStep($event)"
                   ></app-intro>
                 }
-<!--                @if (currentStep() === StepKey.Details && stepVisible()) {-->
-<!--                  <app-details-->
-<!--                    [stepVisible]="stepVisible()"-->
-<!--                    (goToStep)="fadeToStep($event)"-->
-<!--                  ></app-details>-->
-<!--                }-->
+                @if (currentStep() === StepKey.Details && stepVisible()) {
+                  <app-details
+                    [stepVisible]="stepVisible()"
+                    (goToStep)="fadeToStep($event)"
+                  ></app-details>
+                }
 <!--                @if (-->
 <!--                  currentStep() === StepKey.LeaderApplication && stepVisible()-->
 <!--                ) {-->
@@ -157,7 +166,7 @@ import { environment } from '../../environments/environment';
 })
 export class FormComponent {
   protected readonly StepKey = StepKey;
-  currentStep = signal<number>(StepKey.Intro);
+  currentStep = signal<number>(StepKey.Lookup);
 
   stepVisible = signal(true);
   isSubmitting = signal(false);
@@ -217,6 +226,12 @@ export class FormComponent {
         this.isSubmitting.set(false); // stop loader
       },
     });
+  }
+
+  onSelectedCamper(camper: { id: number; firstName: string; lastName: string; year: number }) {
+    // PR 5 will replace this with sending a verification code to the parent_email
+    // on file and gating the edit flow behind it.
+    console.log('selected camper (PR 5 will wire this up):', camper);
   }
 
   fadeToStep(step: keyof typeof StepKey | number) {

--- a/src/app/intro/intro.component.spec.ts
+++ b/src/app/intro/intro.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { IntroComponent } from './intro.component';
+import { StepKey } from '../../models';
 
 describe('IntroComponent', () => {
   let component: IntroComponent;
@@ -13,11 +14,29 @@ describe('IntroComponent', () => {
     .compileComponents();
 
     fixture = TestBed.createComponent(IntroComponent);
+    fixture.componentRef.setInput('stepVisible', true);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('renders the 2026 dates', () => {
+    const text: string = fixture.nativeElement.textContent;
+    expect(text).toContain('Power Camp 2026');
+    expect(text).toContain('31 July');
+    expect(text).toContain('2 August 2026');
+  });
+
+  it('emits goToStep(Details) when Start Registration is clicked', () => {
+    let emitted: number | undefined;
+    component.goToStep.subscribe((s: number) => (emitted = s));
+
+    const btn = fixture.nativeElement.querySelector('button');
+    btn.click();
+
+    expect(emitted).toBe(StepKey.Details);
   });
 });

--- a/src/app/intro/intro.component.ts
+++ b/src/app/intro/intro.component.ts
@@ -1,6 +1,5 @@
-import { Component, inject, input, output } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { StepKey } from '../../models';
-import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-intro',
@@ -16,34 +15,23 @@ import { Router } from '@angular/router';
         alt="Power Camp group photo"
         class="mb-6 rounded shadow max-h-64 w-auto object-cover"
       />
-      <h1 class="text-3xl font-bold mb-4 text-gray-900">
-        Power Camp 2025 Feedback
-      </h1>
-<div class="w-full">
-  <p class="mt-2 text-md text-gray-500">Powercamp 2025 was blast! Sadly its over. </p>
-  <p class="text-md text-gray-500">If you need to contact the admin team you can drop us a mail: <a [href]="'mailto:' + 'powercamplife' + '@' + 'gmail.com'" class="text-blue-600 underline">{{ 'powercamplife' + '@' + 'gmail.com' }}</a></p>
-  <p class="mt-2 text-md text-gray-500">Please click the feedback button to give your thoughts on PC '25</p>
-</div>
-<!--      <p class="mt-2 text-md text-gray-500">-->
-<!--        This form is your ticket to all the details - the what, the when, the-->
-<!--        how, and all the other groovy info for Power Camp 2025.-->
-<!--      </p>-->
-<!--      <p class="mt-2 text-md text-gray-500">-->
-<!--        Here's the deal: Each camper, even if they're from the same family, must-->
-<!--        complete this form. It's your key to unlocking the adventure ahead!-->
-<!--      </p>-->
+      <h1 class="text-3xl font-bold mb-4 text-gray-900">Power Camp 2026</h1>
+      <div class="w-full">
+        <p class="mt-2 text-md text-gray-500">
+          Power Camp 2026 runs <span class="font-semibold">Friday 31 July – Sunday 2 August 2026</span>.
+        </p>
+        <p class="mt-2 text-md text-gray-500">
+          This form is your ticket to all the details and your spot at camp. Each
+          camper, even from the same family, must complete it themselves.
+        </p>
+      </div>
       <div class="flex w-full justify-between">
-<!--        <button-->
-<!--          type="button"-->
-<!--          (click)="goToStep.emit(StepKey.Details)"-->
-<!--          class="rounded-full bg-white mt-4 px-4 py-2.5 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50"-->
-<!--        >-->
-<!--          Start Registration-->
-<!--        </button>-->
         <button
+          type="button"
+          (click)="goToStep.emit(StepKey.Details)"
           class="rounded-full bg-white mt-4 px-4 py-2.5 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50"
-          (click)="navigateToFeedback()"
-        >Give us feedback
+        >
+          Start Registration
         </button>
       </div>
     </div>
@@ -51,16 +39,7 @@ import { Router } from '@angular/router';
   styles: ``,
 })
 export class IntroComponent {
-  router = inject(Router);
   stepVisible = input.required<boolean>();
   goToStep = output<StepKey>();
   StepKey = StepKey;
-
-  navigateToConsent():void {
-    this.router.navigate(['consent']);
-  }
-
-  navigateToFeedback() {
-    this.router.navigate(['feedback']);
-  }
 }

--- a/src/app/lookup/lookup.component.spec.ts
+++ b/src/app/lookup/lookup.component.spec.ts
@@ -1,0 +1,103 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { LookupComponent } from './lookup.component';
+import { LookupResult, StepKey } from '../../models';
+import { environment } from '../../environments/environment';
+
+describe('LookupComponent', () => {
+  let fixture: ComponentFixture<LookupComponent>;
+  let component: LookupComponent;
+  let http: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LookupComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LookupComponent);
+    fixture.componentRef.setInput('stepVisible', true);
+    component = fixture.componentInstance;
+    http = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => http.verify());
+
+  it('does not call the API when the query is empty', () => {
+    component.queryControl.setValue('');
+    component.search();
+    http.expectNone(`${environment.baseApi}/lookup`);
+  });
+
+  it('POSTs to /lookup with the trimmed query and renders results', () => {
+    const fakeResults: LookupResult[] = [
+      { id: 1, firstName: 'Emma', lastName: 'Cable', year: 2025, parentEmailMasked: 'ji***@me.com' },
+    ];
+
+    component.queryControl.setValue('  emma  ');
+    component.search();
+
+    const req = http.expectOne(`${environment.baseApi}/lookup`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ q: 'emma' });
+
+    req.flush({ results: fakeResults });
+    fixture.detectChanges();
+
+    expect(component.results()).toEqual(fakeResults);
+    expect(component.loading()).toBe(false);
+    const list = fixture.nativeElement.querySelector('[data-testid="results"]');
+    expect(list).toBeTruthy();
+    expect(list.textContent).toContain('Emma');
+    expect(list.textContent).toContain('Cable');
+    expect(list.textContent).toContain('ji***@me.com');
+  });
+
+  it('renders the no-results message on an empty array', () => {
+    component.queryControl.setValue('zzz');
+    component.search();
+    http.expectOne(`${environment.baseApi}/lookup`).flush({ results: [] });
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="no-results"]')).toBeTruthy();
+  });
+
+  it('shows an error and clears loading on HTTP failure', () => {
+    component.queryControl.setValue('emma');
+    component.search();
+
+    http.expectOne(`${environment.baseApi}/lookup`).flush(
+      { error: 'Lookup failed' },
+      { status: 500, statusText: 'Server Error' }
+    );
+    fixture.detectChanges();
+
+    expect(component.loading()).toBe(false);
+    expect(component.error()).toMatch(/Search failed/i);
+    expect(fixture.nativeElement.querySelector('[data-testid="error"]')).toBeTruthy();
+  });
+
+  it('emits selectedCamper when "This is me" is clicked', () => {
+    const result: LookupResult = {
+      id: 7, firstName: 'Emma', lastName: 'Cable', year: 2025, parentEmailMasked: 'ji***@me.com',
+    };
+    let emitted: LookupResult | undefined;
+    component.selectedCamper.subscribe((r) => (emitted = r));
+
+    component.select(result);
+    expect(emitted).toEqual(result);
+  });
+
+  it('emits goToStep(Intro) when "Register as a new camper" is clicked', () => {
+    let emitted: StepKey | undefined;
+    component.goToStep.subscribe((s) => (emitted = s));
+
+    component.registerNew();
+    expect(emitted).toBe(StepKey.Intro);
+  });
+});

--- a/src/app/lookup/lookup.component.ts
+++ b/src/app/lookup/lookup.component.ts
@@ -1,0 +1,126 @@
+import { Component, inject, input, output, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { HttpClient } from '@angular/common/http';
+import { LookupResult, StepKey } from '../../models';
+import { environment } from '../../environments/environment';
+
+@Component({
+  selector: 'app-lookup',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  template: `
+    <div
+      class="customer-wrapper p-6"
+      [class.opacity-0]="!stepVisible()"
+      [class.opacity-100]="stepVisible()"
+    >
+      <h1 class="text-3xl font-bold mb-2 text-gray-900">Power Camp 2026</h1>
+      <p class="mb-6 text-md text-gray-500">
+        Have you been to Power Camp before? Search for your name to pick up where you left off.
+      </p>
+
+      <div class="flex gap-2 mb-4">
+        <input
+          type="text"
+          [formControl]="queryControl"
+          (keyup.enter)="search()"
+          placeholder="First or last name"
+          class="border rounded px-3 py-2 w-full"
+          autocomplete="off"
+        />
+        <button
+          type="button"
+          (click)="search()"
+          [disabled]="loading() || !queryControl.value?.trim()"
+          class="bg-green-300 text-green-900 px-6 py-2 rounded disabled:bg-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed"
+        >
+          {{ loading() ? 'Searching…' : 'Search' }}
+        </button>
+      </div>
+
+      @if (error()) {
+        <div class="text-red-600 mb-4" data-testid="error">{{ error() }}</div>
+      }
+
+      @if (results() !== null) {
+        @if (results()!.length === 0) {
+          <div class="text-gray-500 mb-4" data-testid="no-results">
+            No matches. You can register as a new camper below.
+          </div>
+        } @else {
+          <ul class="border rounded divide-y" data-testid="results">
+            @for (r of results(); track r.id) {
+              <li class="p-3 flex items-center justify-between hover:bg-gray-50">
+                <div>
+                  <div class="font-medium text-gray-900">{{ r.firstName }} {{ r.lastName }}</div>
+                  <div class="text-sm text-gray-500">
+                    {{ r.year }} · {{ r.parentEmailMasked }}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  class="text-sm bg-indigo-100 text-indigo-700 px-3 py-1 rounded"
+                  (click)="select(r)"
+                >
+                  This is me
+                </button>
+              </li>
+            }
+          </ul>
+        }
+
+        <button
+          type="button"
+          (click)="registerNew()"
+          class="mt-6 px-6 py-2 rounded border border-gray-300 text-gray-600"
+        >
+          Register as a new camper
+        </button>
+      }
+    </div>
+  `,
+  styles: ``,
+})
+export class LookupComponent {
+  stepVisible = input.required<boolean>();
+  goToStep = output<StepKey>();
+  selectedCamper = output<LookupResult>();
+
+  queryControl = new FormControl('');
+  results = signal<LookupResult[] | null>(null);
+  loading = signal(false);
+  error = signal<string | null>(null);
+
+  private readonly http = inject(HttpClient);
+
+  search() {
+    const q = (this.queryControl.value ?? '').trim();
+    if (!q) return;
+
+    this.loading.set(true);
+    this.error.set(null);
+    this.results.set(null);
+
+    this.http
+      .post<{ results: LookupResult[] }>(`${environment.baseApi}/lookup`, { q })
+      .subscribe({
+        next: (res) => {
+          this.results.set(res.results);
+          this.loading.set(false);
+        },
+        error: () => {
+          this.error.set('Search failed. Please try again.');
+          this.loading.set(false);
+        },
+      });
+  }
+
+  select(r: LookupResult) {
+    this.selectedCamper.emit(r);
+  }
+
+  registerNew() {
+    this.goToStep.emit(StepKey.Intro);
+  }
+}

--- a/src/models.ts
+++ b/src/models.ts
@@ -18,19 +18,28 @@ export interface CampFormData {
 }
 
 export enum StepKey {
-  Intro = 0,
-  Details = 1,
-  CamperInfo = 2,
-  CamperAdditionalInfo = 3,
-  Friends = 4,
-  Medical = 5,
-  ParentInfo = 6,
-  Tshirt = 7,
-  Church = 8,
-  OtherInfo = 9,
-  CheckData = 10,
-  LeaderApplication = 11,
-  LeaderQuestion = 12,
+  Lookup = 0,
+  Intro = 1,
+  Details = 2,
+  CamperInfo = 3,
+  CamperAdditionalInfo = 4,
+  Friends = 5,
+  Medical = 6,
+  ParentInfo = 7,
+  Tshirt = 8,
+  Church = 9,
+  OtherInfo = 10,
+  CheckData = 11,
+  LeaderApplication = 12,
+  LeaderQuestion = 13,
+}
+
+export interface LookupResult {
+  id: number;
+  firstName: string;
+  lastName: string;
+  year: number;
+  parentEmailMasked: string;
 }
 export enum consentKey {
   Intro


### PR DESCRIPTION
Backend:
- New POST /lookup endpoint: case-insensitive partial match on first OR last name (drizzle ilike), excluding soft-deleted rows. Returns up to 50 hits ordered by year desc, with parent emails masked (e.g. ji***@me.com) so search isn't a free dump of personal info. Mounted in server.ts. Tests cover the route, the email-masking helper and the no-match / 400 / 500 paths.

Frontend:
- New LookupComponent (src/app/lookup) — search input + button
  + results list. Each result has a 'This is me' button (emits selectedCamper for the next PR to wire up to a verification-code flow) and a fallback 'Register as a new camper' button that goes to Intro.
- StepKey: prepended Lookup = 0, renumbered the rest. Lookup is now the form's initial step.
- Exported a LookupResult interface for typed sharing.

Intro:
- Replaced the 'PowerCamp 2025 is over, give feedback' content with a 2026 welcome screen. Dates shown: Friday 31 July – Sunday 2 August 2026. The Start Registration button emits goToStep(Details). Removed the Router import and feedback CTA — we no longer route to feedback from the registration entrypoint.
- Spec now sets the required stepVisible input before detectChanges, plus two new assertions for the dates and the goToStep emission.

Details:
- Updated dates to Fri 31 July 2026 17:00 → Sun 2 August 2026 14:00 to match the new camp dates.
- Re-enabled in form.component.ts so Intro → Details now works end-to-end. The remaining steps stay commented out and will come back in subsequent PRs.