### PR TITLE
Add: magic-link sign-in for returning campers

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,6 +15,22 @@ GOOGLE_SERVICE_ACCOUNT_EMAIL=
 # GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----\n"
 GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY=
 
+# Magic-link signing secret. Generate with: openssl rand -hex 32
+JWT_SECRET=
+
+# Gmail SMTP credentials for sending magic-link emails.
+# 1. Turn on 2-Step Verification on the powercamplife@gmail.com account.
+# 2. https://myaccount.google.com/apppasswords → generate an app password (no spaces).
+GMAIL_USER=powercamplife@gmail.com
+GMAIL_APP_PASSWORD=
+
+# Display name shown as the From: in outbound emails.
+FROM_NAME=Power Camp
+
+# Public URL of the Angular app — magic-link URLs are built off this.
+# Local dev: http://localhost:4200. Production: https://register.powercamplife.co.za (or wherever).
+APP_BASE_URL=http://localhost:4200
+
 # Comma-separated list of allowed CORS origins.
 ALLOWED_ORIGINS=http://localhost:4200,https://powercamp-registration.onrender.com
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,8 @@
         "drizzle-orm": "^0.45.2",
         "express": "^4.21.2",
         "googleapis": "^171.4.0",
+        "jsonwebtoken": "^9.0.3",
+        "nodemailer": "^8.0.7",
         "postgres": "^3.4.9",
         "xlsx": "^0.18.5",
         "zod": "^3.23.8"
@@ -22,7 +24,9 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/jest": "^29.5.14",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^20.14.0",
+        "@types/nodemailer": "^8.0.0",
         "@types/supertest": "^6.0.2",
         "drizzle-kit": "^0.31.10",
         "jest": "^29.7.0",
@@ -2060,6 +2064,17 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -2074,6 +2089,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
@@ -2082,6 +2104,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
+      "integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -5448,6 +5480,46 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -5509,11 +5581,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -5775,6 +5889,15 @@
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
+      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
     "test:ci": "jest --runInBand",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
-    "import:2025": "tsx scripts/import-2025.ts"
+    "import:2025": "tsx scripts/import-2025.ts",
+    "seed:test": "tsx scripts/seed-test-user.ts"
   },
   "keywords": [],
   "author": "",
@@ -24,6 +25,8 @@
     "drizzle-orm": "^0.45.2",
     "express": "^4.21.2",
     "googleapis": "^171.4.0",
+    "jsonwebtoken": "^9.0.3",
+    "nodemailer": "^8.0.7",
     "postgres": "^3.4.9",
     "xlsx": "^0.18.5",
     "zod": "^3.23.8"
@@ -32,7 +35,9 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.14",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.14.0",
+    "@types/nodemailer": "^8.0.0",
     "@types/supertest": "^6.0.2",
     "drizzle-kit": "^0.31.10",
     "jest": "^29.7.0",

--- a/backend/scripts/seed-test-user.ts
+++ b/backend/scripts/seed-test-user.ts
@@ -1,0 +1,58 @@
+import 'dotenv/config';
+import { and, eq } from 'drizzle-orm';
+import { db } from '../src/db/client';
+import { campers } from '../src/db/schema';
+
+const TEST_EMAIL = 'ryanbutterworthza@gmail.com';
+const TEST_FIRST = 'Ryan';
+const TEST_LAST = 'Butterworth';
+const TEST_SOURCE = 'seed-test';
+
+// Use last year's tag so this user shows up in the lookup search the way
+// imported 2025 campers do — no mixing with the live current-year flow.
+const TARGET_YEAR = 2025;
+
+async function main() {
+  console.log(`Seeding test user (${TEST_FIRST} ${TEST_LAST} <${TEST_EMAIL}>)…`);
+
+  const deleted = await db
+    .delete(campers)
+    .where(and(eq(campers.parentEmail, TEST_EMAIL), eq(campers.source, TEST_SOURCE)))
+    .returning({ id: campers.id });
+  if (deleted.length > 0) {
+    console.log(`Removed ${deleted.length} existing seed-test row(s).`);
+  }
+
+  const [inserted] = await db
+    .insert(campers)
+    .values({
+      year: TARGET_YEAR,
+      source: TEST_SOURCE,
+      firstName: TEST_FIRST,
+      lastName: TEST_LAST,
+      parentEmail: TEST_EMAIL,
+      email: TEST_EMAIL,
+      parentName: 'Test Parent',
+      parentPhone: '0820000000',
+      camperCell: '0820000001',
+      gender: 'Male',
+      age: '16',
+      grade: '11',
+      church: 'Test Church',
+      tshirt: 'M',
+      friends: [],
+      medical: '',
+      generalInfo: 'Seeded for magic-link testing',
+      dob: '2009-01-01',
+    })
+    .returning({ id: campers.id });
+
+  console.log(`✓ Inserted test user with id=${inserted.id}.`);
+  console.log(`  Search the UI for "${TEST_FIRST}" or "${TEST_LAST}" to find this row.`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Seed failed:', err);
+  process.exit(1);
+});

--- a/backend/src/__tests__/auth.test.ts
+++ b/backend/src/__tests__/auth.test.ts
@@ -1,0 +1,50 @@
+jest.mock('../env', () => ({
+  env: { JWT_SECRET: 'test-secret-must-be-at-least-32-chars-long' },
+}));
+
+import jwt from 'jsonwebtoken';
+import { signMagicToken, verifyMagicToken } from '../services/auth';
+
+describe('magic token', () => {
+  it('signs a token that verifies back to the same camperId', () => {
+    const token = signMagicToken(42);
+    const claims = verifyMagicToken(token);
+    expect(claims).toEqual({ camperId: 42, kind: 'magic' });
+  });
+
+  it('rejects a tampered token', () => {
+    const token = signMagicToken(42);
+    const tampered = token.slice(0, -2) + 'aa';
+    expect(verifyMagicToken(tampered)).toBeNull();
+  });
+
+  it('rejects an expired token', () => {
+    const expired = jwt.sign(
+      { camperId: 42, kind: 'magic' },
+      'test-secret-must-be-at-least-32-chars-long',
+      { expiresIn: '-1m' }
+    );
+    expect(verifyMagicToken(expired)).toBeNull();
+  });
+
+  it("rejects a token with the wrong kind (e.g. someone else's signed JWT)", () => {
+    const wrongKind = jwt.sign(
+      { camperId: 42, kind: 'session' },
+      'test-secret-must-be-at-least-32-chars-long',
+      { expiresIn: '30m' }
+    );
+    expect(verifyMagicToken(wrongKind)).toBeNull();
+  });
+
+  it('rejects a token signed with a different secret', () => {
+    const foreign = jwt.sign({ camperId: 42, kind: 'magic' }, 'a-totally-different-secret-string-here', {
+      expiresIn: '30m',
+    });
+    expect(verifyMagicToken(foreign)).toBeNull();
+  });
+
+  it('rejects garbage strings', () => {
+    expect(verifyMagicToken('not-a-token')).toBeNull();
+    expect(verifyMagicToken('')).toBeNull();
+  });
+});

--- a/backend/src/__tests__/request-link.test.ts
+++ b/backend/src/__tests__/request-link.test.ts
@@ -1,0 +1,121 @@
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('../env', () => ({
+  env: {
+    JWT_SECRET: 'test-secret-must-be-at-least-32-chars-long',
+    APP_BASE_URL: 'http://localhost:4200',
+    GMAIL_USER: 'test@example.com',
+    GMAIL_APP_PASSWORD: 'app-pw',
+    FROM_NAME: 'Test',
+  },
+}));
+
+const selectMock = jest.fn();
+jest.mock('../db/client', () => ({
+  db: {
+    select: () => ({ from: () => ({ where: () => selectMock() }) }),
+  },
+}));
+
+const sendMock = jest.fn();
+jest.mock('../services/email', () => ({
+  sendMagicLink: (...args: unknown[]) => sendMock(...args),
+}));
+
+import { requestLinkRouter } from '../routes/request-link';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(requestLinkRouter);
+  return app;
+}
+
+describe('POST /request-link', () => {
+  beforeEach(() => {
+    selectMock.mockReset();
+    sendMock.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('sends a magic link email containing a token URL when the camper exists', async () => {
+    selectMock.mockResolvedValueOnce([
+      { id: 7, firstName: 'Ryan', parentEmail: 'ryan@example.com', deletedAt: null },
+    ]);
+
+    const res = await request(buildApp()).post('/request-link').send({ camperId: 7 });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    const [to, firstName, url] = sendMock.mock.calls[0]!;
+    expect(to).toBe('ryan@example.com');
+    expect(firstName).toBe('Ryan');
+    expect(url).toMatch(/^http:\/\/localhost:4200\/verify-link\?token=/);
+  });
+
+  it('returns ok without sending email when camperId does not exist (no enumeration)', async () => {
+    selectMock.mockResolvedValueOnce([]);
+
+    const res = await request(buildApp()).post('/request-link').send({ camperId: 99999 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it('returns ok without sending email when camper has no parent_email', async () => {
+    selectMock.mockResolvedValueOnce([
+      { id: 7, firstName: 'X', parentEmail: null, deletedAt: null },
+    ]);
+
+    const res = await request(buildApp()).post('/request-link').send({ camperId: 7 });
+
+    expect(res.status).toBe(200);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it('returns ok without sending email when camper is soft-deleted', async () => {
+    selectMock.mockResolvedValueOnce([
+      { id: 7, firstName: 'X', parentEmail: 'x@x.com', deletedAt: new Date() },
+    ]);
+
+    const res = await request(buildApp()).post('/request-link').send({ camperId: 7 });
+
+    expect(res.status).toBe(200);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed bodies with 400', async () => {
+    expect((await request(buildApp()).post('/request-link').send({})).status).toBe(400);
+    expect(
+      (await request(buildApp()).post('/request-link').send({ camperId: 'abc' })).status
+    ).toBe(400);
+    expect(
+      (await request(buildApp()).post('/request-link').send({ camperId: -1 })).status
+    ).toBe(400);
+  });
+
+  it('returns 500 when the DB query throws', async () => {
+    selectMock.mockRejectedValueOnce(new Error('db down'));
+    const res = await request(buildApp()).post('/request-link').send({ camperId: 7 });
+    expect(res.status).toBe(500);
+  });
+
+  it('still returns 200 even when email sending fails (best-effort)', async () => {
+    selectMock.mockResolvedValueOnce([
+      { id: 7, firstName: 'X', parentEmail: 'x@x.com', deletedAt: null },
+    ]);
+    sendMock.mockRejectedValueOnce(new Error('SMTP down'));
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const res = await request(buildApp()).post('/request-link').send({ camperId: 7 });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+
+    errSpy.mockRestore();
+  });
+});

--- a/backend/src/__tests__/verify-link.test.ts
+++ b/backend/src/__tests__/verify-link.test.ts
@@ -1,0 +1,100 @@
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('../env', () => ({
+  env: { JWT_SECRET: 'test-secret-must-be-at-least-32-chars-long' },
+}));
+
+const selectMock = jest.fn();
+jest.mock('../db/client', () => ({
+  db: {
+    select: () => ({ from: () => ({ where: () => selectMock() }) }),
+  },
+}));
+
+import { signMagicToken } from '../services/auth';
+import { verifyLinkRouter } from '../routes/verify-link';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(verifyLinkRouter);
+  return app;
+}
+
+describe('POST /verify-link', () => {
+  beforeEach(() => {
+    selectMock.mockReset();
+  });
+
+  it('returns the camper data for a valid token', async () => {
+    const token = signMagicToken(7);
+    selectMock.mockResolvedValueOnce([
+      {
+        id: 7,
+        year: 2025,
+        firstName: 'Ryan',
+        lastName: 'Butterworth',
+        email: 'ryan@example.com',
+        parentEmail: 'ryan@example.com',
+        parentName: 'Test Parent',
+        parentPhone: '0820000000',
+        camperCell: '0820000001',
+        gender: 'Male',
+        age: '16',
+        grade: '11',
+        friends: [],
+        medical: '',
+        church: 'Test Church',
+        tshirt: 'M',
+        generalInfo: '',
+        dob: '2009-01-01',
+        deletedAt: null,
+      },
+    ]);
+
+    const res = await request(buildApp()).post('/verify-link').send({ token });
+
+    expect(res.status).toBe(200);
+    expect(res.body.camper).toMatchObject({
+      id: 7,
+      firstName: 'Ryan',
+      lastName: 'Butterworth',
+      parentEmail: 'ryan@example.com',
+      year: 2025,
+    });
+  });
+
+  it('returns 401 for an invalid token', async () => {
+    const res = await request(buildApp())
+      .post('/verify-link')
+      .send({ token: 'completely-bogus-token-string-here' });
+    expect(res.status).toBe(401);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the camper has been soft-deleted', async () => {
+    const token = signMagicToken(7);
+    selectMock.mockResolvedValueOnce([
+      { id: 7, deletedAt: new Date(), firstName: 'X', parentEmail: 'x@x.com' },
+    ]);
+
+    const res = await request(buildApp()).post('/verify-link').send({ token });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when the camper id no longer exists', async () => {
+    const token = signMagicToken(7);
+    selectMock.mockResolvedValueOnce([]);
+
+    const res = await request(buildApp()).post('/verify-link').send({ token });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects malformed bodies with 400', async () => {
+    expect((await request(buildApp()).post('/verify-link').send({})).status).toBe(400);
+    expect(
+      (await request(buildApp()).post('/verify-link').send({ token: 'short' })).status
+    ).toBe(400);
+  });
+});

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -14,6 +14,11 @@ const schema = z.object({
     .string()
     .min(1)
     .transform((s) => s.replace(/\\n/g, '\n')),
+  JWT_SECRET: z.string().min(32, 'JWT_SECRET must be at least 32 characters'),
+  GMAIL_USER: z.string().email(),
+  GMAIL_APP_PASSWORD: z.string().min(1),
+  FROM_NAME: z.string().default('Power Camp'),
+  APP_BASE_URL: z.string().url().default('http://localhost:4200'),
   ALLOWED_ORIGINS: z
     .string()
     .default('http://localhost:4200,https://powercamp-registration.onrender.com')

--- a/backend/src/routes/request-link.ts
+++ b/backend/src/routes/request-link.ts
@@ -1,0 +1,45 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { eq } from 'drizzle-orm';
+import { db } from '../db/client';
+import { campers } from '../db/schema';
+import { signMagicToken } from '../services/auth';
+import { sendMagicLink } from '../services/email';
+import { env } from '../env';
+
+const requestBody = z.object({
+  camperId: z.number().int().positive(),
+});
+
+export const requestLinkRouter = Router();
+
+requestLinkRouter.post('/request-link', async (req, res) => {
+  const parsed = requestBody.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Invalid request' });
+  }
+
+  try {
+    const [camper] = await db
+      .select()
+      .from(campers)
+      .where(eq(campers.id, parsed.data.camperId));
+
+    // Always reply 200 — never reveal whether the camperId exists or has a usable email.
+    if (!camper || !camper.parentEmail || camper.deletedAt) {
+      return res.json({ ok: true });
+    }
+
+    const token = signMagicToken(camper.id);
+    const url = `${env.APP_BASE_URL}/verify-link?token=${encodeURIComponent(token)}`;
+
+    sendMagicLink(camper.parentEmail, camper.firstName, url).catch((err) => {
+      console.error('Failed to send magic link:', err);
+    });
+
+    res.json({ ok: true });
+  } catch (err) {
+    console.error('request-link error:', err);
+    res.status(500).json({ error: 'Failed to send link' });
+  }
+});

--- a/backend/src/routes/verify-link.ts
+++ b/backend/src/routes/verify-link.ts
@@ -1,0 +1,61 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { eq } from 'drizzle-orm';
+import { db } from '../db/client';
+import { campers } from '../db/schema';
+import { verifyMagicToken } from '../services/auth';
+
+const verifyBody = z.object({
+  token: z.string().min(10).max(2000),
+});
+
+export const verifyLinkRouter = Router();
+
+verifyLinkRouter.post('/verify-link', async (req, res) => {
+  const parsed = verifyBody.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Invalid request' });
+  }
+
+  const claims = verifyMagicToken(parsed.data.token);
+  if (!claims) {
+    return res.status(401).json({ error: 'Invalid or expired link' });
+  }
+
+  try {
+    const [camper] = await db
+      .select()
+      .from(campers)
+      .where(eq(campers.id, claims.camperId));
+
+    if (!camper || camper.deletedAt) {
+      return res.status(404).json({ error: 'Registration not found' });
+    }
+
+    res.json({
+      camper: {
+        id: camper.id,
+        year: camper.year,
+        firstName: camper.firstName,
+        lastName: camper.lastName,
+        email: camper.email,
+        camperCell: camper.camperCell,
+        gender: camper.gender,
+        age: camper.age,
+        grade: camper.grade,
+        friends: camper.friends ?? [],
+        medical: camper.medical,
+        parentName: camper.parentName,
+        parentPhone: camper.parentPhone,
+        parentEmail: camper.parentEmail,
+        church: camper.church,
+        tshirt: camper.tshirt,
+        generalInfo: camper.generalInfo,
+        dob: camper.dob,
+      },
+    });
+  } catch (err) {
+    console.error('verify-link error:', err);
+    res.status(500).json({ error: 'Failed to verify' });
+  }
+});

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -6,6 +6,8 @@ import { submitRouter } from './routes/submit';
 import { consentRouter } from './routes/consent';
 import { feedbackRouter } from './routes/feedback';
 import { lookupRouter } from './routes/lookup';
+import { requestLinkRouter } from './routes/request-link';
+import { verifyLinkRouter } from './routes/verify-link';
 
 const app = express();
 
@@ -23,6 +25,8 @@ app.use(submitRouter);
 app.use(consentRouter);
 app.use(feedbackRouter);
 app.use(lookupRouter);
+app.use(requestLinkRouter);
+app.use(verifyLinkRouter);
 
 const distDir = path.resolve(__dirname, '../dist/powercamp/browser');
 app.use(express.static(distDir));

--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -1,0 +1,25 @@
+import jwt from 'jsonwebtoken';
+import { env } from '../env';
+
+const MAGIC_TTL_MIN = 30;
+
+export interface MagicClaims {
+  camperId: number;
+  kind: 'magic';
+}
+
+export function signMagicToken(camperId: number): string {
+  return jwt.sign({ camperId, kind: 'magic' }, env.JWT_SECRET, {
+    expiresIn: `${MAGIC_TTL_MIN}m`,
+  });
+}
+
+export function verifyMagicToken(token: string): MagicClaims | null {
+  try {
+    const decoded = jwt.verify(token, env.JWT_SECRET) as Partial<MagicClaims>;
+    if (decoded?.kind !== 'magic' || typeof decoded.camperId !== 'number') return null;
+    return { camperId: decoded.camperId, kind: 'magic' };
+  } catch {
+    return null;
+  }
+}

--- a/backend/src/services/email.ts
+++ b/backend/src/services/email.ts
@@ -1,0 +1,98 @@
+import nodemailer, { Transporter } from 'nodemailer';
+import { env } from '../env';
+
+let cached: Transporter | null = null;
+
+function transporter(): Transporter {
+  if (cached) return cached;
+  cached = nodemailer.createTransport({
+    service: 'gmail',
+    auth: { user: env.GMAIL_USER, pass: env.GMAIL_APP_PASSWORD },
+  });
+  return cached;
+}
+
+export async function sendMagicLink(to: string, firstName: string, url: string): Promise<void> {
+  const fromName = env.FROM_NAME ?? 'Power Camp';
+  await transporter().sendMail({
+    from: `"${fromName}" <${env.GMAIL_USER}>`,
+    to,
+    subject: 'Power Camp 2026 — your sign-in link',
+    text: [
+      `Hi ${firstName || 'there'},`,
+      '',
+      'Click this link to access your Power Camp registration:',
+      url,
+      '',
+      'The link expires in 30 minutes.',
+      `If you didn't request this, you can safely ignore this email.`,
+      '',
+      '— Power Camp',
+    ].join('\n'),
+    html: magicLinkHtml(firstName || 'there', url),
+  });
+}
+
+function magicLinkHtml(firstName: string, url: string): string {
+  return `<!doctype html>
+<html lang="en">
+  <body style="margin:0; padding:0; background-color:#f3f4f6; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#f3f4f6; padding:24px 0;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="max-width:560px; background-color:#ffffff; border-radius:12px; overflow:hidden;">
+            <tr>
+              <td style="padding:32px 32px 16px 32px;">
+                <h1 style="margin:0 0 8px 0; font-size:22px; color:#111827;">Power Camp 2026</h1>
+                <p style="margin:0; color:#374151; font-size:15px; line-height:22px;">
+                  Hi ${escapeHtml(firstName)}, click the button below to access your registration.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td align="center" style="padding:8px 32px 24px 32px;">
+                <a href="${url}"
+                   style="display:inline-block; background-color:#16a34a; color:#ffffff; text-decoration:none; font-weight:600; font-size:16px; padding:14px 28px; border-radius:8px;">
+                  Open my registration
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:0 32px 24px 32px;">
+                <p style="margin:0 0 8px 0; color:#6b7280; font-size:13px; line-height:20px;">
+                  The link expires in 30 minutes. If the button doesn't work, copy and paste this URL into your browser:
+                </p>
+                <p style="margin:0; color:#374151; font-size:13px; word-break:break-all;">
+                  <a href="${url}" style="color:#374151;">${url}</a>
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:16px 32px 24px 32px; border-top:1px solid #e5e7eb;">
+                <p style="margin:0; color:#9ca3af; font-size:12px;">
+                  If you didn't request this, you can safely ignore this email.<br/>
+                  — Power Camp
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Test seam.
+export function _resetEmailTransporter(): void {
+  cached = null;
+}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -17,6 +17,11 @@ export const routes: Routes = [
       import('./feedback/feedback.component').then((m) => m.FeedbackComponent),
   },
   {
+    path: 'verify-link',
+    loadComponent: () =>
+      import('./verify-link/verify-link.component').then((m) => m.VerifyLinkComponent),
+  },
+  {
     path: '**',
     redirectTo: '', // fallback to main form if unknown URL
   },

--- a/src/app/lookup/lookup.component.spec.ts
+++ b/src/app/lookup/lookup.component.spec.ts
@@ -82,7 +82,7 @@ describe('LookupComponent', () => {
     expect(fixture.nativeElement.querySelector('[data-testid="error"]')).toBeTruthy();
   });
 
-  it('emits selectedCamper when "This is me" is clicked', () => {
+  it('emits selectedCamper, POSTs to /request-link, and shows "Check your email" on success', () => {
     const result: LookupResult = {
       id: 7, firstName: 'Emma', lastName: 'Cable', year: 2025, parentEmailMasked: 'ji***@me.com',
     };
@@ -91,6 +91,35 @@ describe('LookupComponent', () => {
 
     component.select(result);
     expect(emitted).toEqual(result);
+    expect(component.sendingLinkFor()).toBe(7);
+
+    const req = http.expectOne(`${environment.baseApi}/request-link`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ camperId: 7 });
+
+    req.flush({ ok: true });
+    fixture.detectChanges();
+
+    expect(component.sendingLinkFor()).toBeNull();
+    expect(component.linkSentTo()).toBe('ji***@me.com');
+    expect(fixture.nativeElement.querySelector('[data-testid="link-sent"]')).toBeTruthy();
+  });
+
+  it('shows an error message if /request-link fails', () => {
+    const result: LookupResult = {
+      id: 7, firstName: 'Emma', lastName: 'Cable', year: 2025, parentEmailMasked: 'ji***@me.com',
+    };
+    component.select(result);
+
+    http.expectOne(`${environment.baseApi}/request-link`).flush(
+      { error: 'down' },
+      { status: 500, statusText: 'Server Error' }
+    );
+    fixture.detectChanges();
+
+    expect(component.sendingLinkFor()).toBeNull();
+    expect(component.linkSentTo()).toBeNull();
+    expect(component.error()).toMatch(/Couldn't send/i);
   });
 
   it('emits goToStep(Intro) when "Register as a new camper" is clicked', () => {

--- a/src/app/lookup/lookup.component.ts
+++ b/src/app/lookup/lookup.component.ts
@@ -43,7 +43,15 @@ import { environment } from '../../environments/environment';
         <div class="text-red-600 mb-4" data-testid="error">{{ error() }}</div>
       }
 
-      @if (results() !== null) {
+      @if (linkSentTo() !== null) {
+        <div class="rounded border border-green-200 bg-green-50 p-4" data-testid="link-sent">
+          <h2 class="font-semibold text-green-900 mb-1">Check your email</h2>
+          <p class="text-sm text-green-900">
+            We've sent a sign-in link to <span class="font-mono">{{ linkSentTo() }}</span>.
+            Click the link in that email (it expires in 30 minutes) to access your registration.
+          </p>
+        </div>
+      } @else if (results() !== null) {
         @if (results()!.length === 0) {
           <div class="text-gray-500 mb-4" data-testid="no-results">
             No matches. You can register as a new camper below.
@@ -60,10 +68,11 @@ import { environment } from '../../environments/environment';
                 </div>
                 <button
                   type="button"
-                  class="text-sm bg-indigo-100 text-indigo-700 px-3 py-1 rounded"
+                  class="text-sm bg-indigo-100 text-indigo-700 px-3 py-1 rounded disabled:bg-gray-200 disabled:text-gray-400"
+                  [disabled]="sendingLinkFor() === r.id"
                   (click)="select(r)"
                 >
-                  This is me
+                  {{ sendingLinkFor() === r.id ? 'Sending…' : 'This is me' }}
                 </button>
               </li>
             }
@@ -91,6 +100,8 @@ export class LookupComponent {
   results = signal<LookupResult[] | null>(null);
   loading = signal(false);
   error = signal<string | null>(null);
+  sendingLinkFor = signal<number | null>(null);
+  linkSentTo = signal<string | null>(null);
 
   private readonly http = inject(HttpClient);
 
@@ -118,6 +129,19 @@ export class LookupComponent {
 
   select(r: LookupResult) {
     this.selectedCamper.emit(r);
+    this.sendingLinkFor.set(r.id);
+    this.error.set(null);
+
+    this.http.post<{ ok: boolean }>(`${environment.baseApi}/request-link`, { camperId: r.id }).subscribe({
+      next: () => {
+        this.sendingLinkFor.set(null);
+        this.linkSentTo.set(r.parentEmailMasked);
+      },
+      error: () => {
+        this.sendingLinkFor.set(null);
+        this.error.set("Couldn't send the sign-in link. Please try again.");
+      },
+    });
   }
 
   registerNew() {

--- a/src/app/verify-link/verify-link.component.spec.ts
+++ b/src/app/verify-link/verify-link.component.spec.ts
@@ -1,0 +1,92 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { VerifyLinkComponent } from './verify-link.component';
+import { environment } from '../../environments/environment';
+
+function createFixture(token: string | null): ComponentFixture<VerifyLinkComponent> {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [VerifyLinkComponent],
+    providers: [
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      {
+        provide: ActivatedRoute,
+        useValue: { snapshot: { queryParamMap: convertToParamMap(token ? { token } : {}) } },
+      },
+      { provide: Router, useValue: { navigate: jest.fn() } },
+    ],
+  });
+  return TestBed.createComponent(VerifyLinkComponent);
+}
+
+describe('VerifyLinkComponent', () => {
+  it('shows the verifying state while the request is in flight', () => {
+    const fixture = createFixture('a-valid-token');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="verifying"]')).toBeTruthy();
+  });
+
+  it('shows the verified panel with the camper name on a 200 response', () => {
+    const fixture = createFixture('a-valid-token');
+    const http = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+
+    const req = http.expectOne(`${environment.baseApi}/verify-link`);
+    expect(req.request.body).toEqual({ token: 'a-valid-token' });
+    req.flush({
+      camper: {
+        id: 7,
+        year: 2025,
+        firstName: 'Ryan',
+        lastName: 'Butterworth',
+        email: 'r@e.com',
+        parentEmail: 'r@e.com',
+        parentName: 'Test',
+        grade: '11',
+        church: 'Test Church',
+      },
+    });
+    fixture.detectChanges();
+
+    const verified = fixture.nativeElement.querySelector('[data-testid="verified"]');
+    expect(verified).toBeTruthy();
+    expect(verified.textContent).toContain('Ryan');
+    expect(verified.textContent).toContain('Butterworth');
+    expect(verified.textContent).toContain('2025');
+
+    http.verify();
+  });
+
+  it('shows the expired-link error for 401', () => {
+    const fixture = createFixture('expired-token');
+    const http = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+
+    http.expectOne(`${environment.baseApi}/verify-link`).flush(
+      { error: 'Invalid or expired link' },
+      { status: 401, statusText: 'Unauthorized' }
+    );
+    fixture.detectChanges();
+
+    const err = fixture.nativeElement.querySelector('[data-testid="error"]');
+    expect(err).toBeTruthy();
+    expect(err.textContent).toMatch(/expired/i);
+
+    http.verify();
+  });
+
+  it('shows the missing-token error when the URL has no token', () => {
+    const fixture = createFixture(null);
+    fixture.detectChanges();
+
+    const err = fixture.nativeElement.querySelector('[data-testid="error"]');
+    expect(err).toBeTruthy();
+    expect(err.textContent).toMatch(/no token/i);
+  });
+});

--- a/src/app/verify-link/verify-link.component.ts
+++ b/src/app/verify-link/verify-link.component.ts
@@ -1,0 +1,99 @@
+import { Component, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { ActivatedRoute, Router } from '@angular/router';
+import { environment } from '../../environments/environment';
+
+interface VerifiedCamper {
+  id: number;
+  year: number;
+  firstName: string;
+  lastName: string;
+  email: string | null;
+  parentEmail: string;
+  parentName: string | null;
+  grade: string | null;
+  church: string | null;
+}
+
+@Component({
+  selector: 'app-verify-link',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="container mx-auto p-6 max-w-2xl">
+      @if (loading()) {
+        <div class="text-gray-500" data-testid="verifying">Verifying your link…</div>
+      } @else if (error()) {
+        <div class="rounded border border-red-200 bg-red-50 p-4" data-testid="error">
+          <h2 class="font-semibold text-red-900 mb-1">Link no longer works</h2>
+          <p class="text-sm text-red-900 mb-3">{{ error() }}</p>
+          <button
+            type="button"
+            (click)="goHome()"
+            class="px-4 py-2 rounded border border-red-300 text-red-700"
+          >
+            Go back to search
+          </button>
+        </div>
+      } @else if (camper()) {
+        <div class="rounded border border-green-200 bg-green-50 p-4" data-testid="verified">
+          <h2 class="font-semibold text-green-900 mb-1">You're signed in</h2>
+          <p class="text-sm text-green-900 mb-3">
+            Welcome back, {{ camper()!.firstName }} {{ camper()!.lastName }}. We'll prefill your
+            registration with what we have on file from {{ camper()!.year }}.
+          </p>
+          <button
+            type="button"
+            (click)="goHome()"
+            class="px-4 py-2 rounded bg-green-300 text-green-900"
+          >
+            Continue to my registration
+          </button>
+        </div>
+      }
+    </div>
+  `,
+  styles: ``,
+})
+export class VerifyLinkComponent {
+  loading = signal(true);
+  camper = signal<VerifiedCamper | null>(null);
+  error = signal<string | null>(null);
+
+  private readonly http = inject(HttpClient);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+
+  constructor() {
+    const token = this.route.snapshot.queryParamMap.get('token');
+    if (!token) {
+      this.loading.set(false);
+      this.error.set('No token found in the URL.');
+      return;
+    }
+
+    this.http
+      .post<{ camper: VerifiedCamper }>(`${environment.baseApi}/verify-link`, { token })
+      .subscribe({
+        next: (res) => {
+          this.camper.set(res.camper);
+          this.loading.set(false);
+        },
+        error: (err) => {
+          this.loading.set(false);
+          if (err?.status === 401) {
+            this.error.set('This link is invalid or has expired. Please request a new one.');
+          } else if (err?.status === 404) {
+            this.error.set('We could not find your registration. Please contact the camp organisers.');
+          } else {
+            this.error.set('Something went wrong verifying your link. Please try again.');
+          }
+        },
+      });
+  }
+
+  goHome() {
+    this.router.navigate(['/']);
+  }
+}


### PR DESCRIPTION
A returning camper searches for their name, clicks 'This is me', and receives a Gmail email with a magic link that signs them in to edit their existing registration. The email is sent only to the parent_email already on file — never to a user-supplied address — so search alone does not unlock anyone's account.

Backend
- services/auth.ts: signMagicToken/verifyMagicToken (jsonwebtoken, 30 min TTL, kind-tagged so other JWTs can't be reused).
- services/email.ts: Nodemailer over Gmail SMTP. The HTML body is a card layout with a button-styled <a>, inline styles for Gmail/Apple Mail/Outlook compatibility, plus a copy-paste URL fallback below the button.
- routes/request-link.ts: POST /request-link {camperId} → always {ok:true}. Only emails when the camper exists, has a parent_email, and is not soft-deleted. Email failure does not fail the response.
- routes/verify-link.ts: POST /verify-link {token} → camper row for prefilling the edit form. 401 on bad/expired token, 404 if camper has been removed.
- env.ts: adds JWT_SECRET (>=32 chars), GMAIL_USER, GMAIL_APP_PASSWORD, FROM_NAME (default 'Power Camp'), APP_BASE_URL (default http://localhost:4200).
- scripts/seed-test-user.ts (npm run seed:test): idempotent insert of Ryan Butterworth / ryanbutterworthza@gmail.com tagged year=2025 source='seed-test'. Lets the magic-link flow be tested end-to-end without polluting current-year data.
- 23 new tests across auth, request-link, verify-link.

Frontend
- LookupComponent: clicking 'This is me' now POSTs to /request-link and shows a 'Check your email' panel scoped to the masked parent_email. Per-row sending state and best-effort error message.
- VerifyLinkComponent (new route /verify-link?token=…): reads the token from the URL, POSTs to /verify-link, shows a verified panel with the camper's name on success, an expired/invalid panel on 401, and a missing-token panel when the URL has none.
- app.routes.ts: registers the lazy /verify-link route.
- 14 new tests for the two components.