### PR TITLE
Production: serve API on the same origin as the Angular app

### DIFF
--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,6 +1,10 @@
+// In production the Express backend serves both the API and the Angular
+// static files from the same origin, so all API calls are same-origin
+// relative paths — no CORS, no hardcoded hostname to keep in sync with
+// the Render service name or the custom domain.
 export const environment = {
   production: true,
-  baseApi: 'https://powercamp-registration.onrender.com',
+  baseApi: '',
   sheetUrl:
     'https://docs.google.com/spreadsheets/d/1emMbGwRAQ2fTkyRtLK7zS1hxIOx55jOCBurz1y-T5dE/edit',
 };


### PR DESCRIPTION
baseApi was hardcoded to https://powercamp-registration.onrender.com which doesn't exist (the live service is powercamp-e008.onrender.com, and the user-facing domain is now powercamplife.co.za). The hardcoded URL also forced CORS for every prod request.

Express already serves both the API routes and the built Angular static files from a single Render web service, so the frontend can hit the API on the same origin via relative paths. Setting baseApi to '' makes ${environment.baseApi}/submit resolve to /submit on whatever hostname the user is currently on — apex, www, or the .onrender.com fallback — no CORS preflight, no stale hostname to update when the service is renamed or the domain changes.

Dev environment is unchanged: it computes baseApi from window.location to point at the local backend on port 3000.