### PR TITLE
Add in-memory rate limiting for login and public form endpoints

### DIFF
--- a/backend/src/__tests__/rate-limit.test.ts
+++ b/backend/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,107 @@
+import express, { Express } from 'express';
+import request from 'supertest';
+import { createRateLimiter, RateLimitOptions } from '../middleware/rate-limit';
+
+// Pin every request to one bucket key so tests don't depend on the client IP
+// supertest happens to present.
+const FIXED_KEY: Pick<RateLimitOptions, 'keyGenerator'> = { keyGenerator: () => 'test-key' };
+
+function buildApp(opts: RateLimitOptions): Express {
+  const app = express();
+  app.use(express.json());
+  app.use(createRateLimiter(opts));
+  app.post('/thing', (_req, res) => {
+    res.json({ ok: true });
+  });
+  app.post('/login', (req, res) => {
+    const ok = req.body?.password === 'right';
+    res.status(ok ? 200 : 401).json({ ok });
+  });
+  return app;
+}
+
+// Let any res.on('finish') handlers (used by skipSuccessfulRequests) run
+// before the next request in the same test.
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('createRateLimiter', () => {
+  it('allows requests up to the limit, then responds 429', async () => {
+    const app = buildApp({ windowMs: 60_000, limit: 3, ...FIXED_KEY });
+
+    for (let i = 0; i < 3; i++) {
+      const res = await request(app).post('/thing').send({});
+      expect(res.status).toBe(200);
+    }
+
+    const blocked = await request(app).post('/thing').send({});
+    expect(blocked.status).toBe(429);
+    expect(blocked.body).toEqual({ error: 'Too many requests, please try again later.' });
+    expect(blocked.headers['retry-after']).toBeDefined();
+  });
+
+  it('uses the custom message in the 429 body', async () => {
+    const app = buildApp({ windowMs: 60_000, limit: 1, message: 'Slow down!', ...FIXED_KEY });
+    await request(app).post('/thing').send({});
+    const blocked = await request(app).post('/thing').send({});
+    expect(blocked.status).toBe(429);
+    expect(blocked.body).toEqual({ error: 'Slow down!' });
+  });
+
+  it('starts a fresh window once the previous one expires', async () => {
+    const app = buildApp({ windowMs: 40, limit: 1, ...FIXED_KEY });
+
+    expect((await request(app).post('/thing').send({})).status).toBe(200);
+    expect((await request(app).post('/thing').send({})).status).toBe(429);
+
+    await new Promise((resolve) => setTimeout(resolve, 60)); // window elapses
+
+    expect((await request(app).post('/thing').send({})).status).toBe(200);
+  });
+
+  it('only counts failed responses when skipSuccessfulRequests is set', async () => {
+    const app = buildApp({
+      windowMs: 60_000,
+      limit: 2,
+      skipSuccessfulRequests: true,
+      ...FIXED_KEY,
+    });
+
+    // Successful logins are rolled back and never accumulate.
+    for (let i = 0; i < 5; i++) {
+      const res = await request(app).post('/login').send({ password: 'right' });
+      expect(res.status).toBe(200);
+      await flush();
+    }
+
+    // Failed logins count: two are allowed, the third is blocked.
+    expect((await request(app).post('/login').send({ password: 'wrong' })).status).toBe(401);
+    await flush();
+    expect((await request(app).post('/login').send({ password: 'wrong' })).status).toBe(401);
+    await flush();
+    expect((await request(app).post('/login').send({ password: 'wrong' })).status).toBe(429);
+  });
+
+  it('bypasses limiting entirely when skip returns true', async () => {
+    const app = buildApp({ windowMs: 60_000, limit: 1, skip: () => true, ...FIXED_KEY });
+    for (let i = 0; i < 5; i++) {
+      expect((await request(app).post('/thing').send({})).status).toBe(200);
+    }
+  });
+
+  it('tracks separate keys independently', async () => {
+    const app = express();
+    app.use(express.json());
+    let n = 0;
+    app.use(createRateLimiter({ windowMs: 60_000, limit: 1, keyGenerator: () => `key-${n}` }));
+    app.post('/thing', (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    n = 1;
+    expect((await request(app).post('/thing').send({})).status).toBe(200);
+    n = 2; // different key — its own fresh allowance
+    expect((await request(app).post('/thing').send({})).status).toBe(200);
+    n = 1; // back to the first key — already used up
+    expect((await request(app).post('/thing').send({})).status).toBe(429);
+  });
+});

--- a/backend/src/middleware/rate-limit.ts
+++ b/backend/src/middleware/rate-limit.ts
@@ -1,0 +1,117 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+
+// A small, dependency-free fixed-window rate limiter.
+//
+// Why hand-rolled rather than `express-rate-limit`? The app runs as a single
+// Render web service, so an in-process counter is sufficient and adds no
+// dependency or build weight. If this ever scales to multiple instances, swap
+// the in-memory Map for a shared store (Redis) or drop in `express-rate-limit`
+// with a `rate-limit-redis` store — the call sites in server.ts stay the same.
+//
+// Keyed by client IP (set `app.set('trust proxy', 1)` so req.ip reflects the
+// real client behind Render's proxy, not the proxy itself).
+
+interface Bucket {
+  count: number;
+  resetAt: number;
+}
+
+export interface RateLimitOptions {
+  /** Length of the rolling window in milliseconds. */
+  windowMs: number;
+  /** Max requests allowed per key per window before 429s start. */
+  limit: number;
+  /**
+   * When true, responses with status < 400 are not counted against the cap.
+   * Used on the login endpoint so a legitimate admin signing in repeatedly is
+   * never locked out — only failed attempts (wrong password) accumulate.
+   */
+  skipSuccessfulRequests?: boolean;
+  /** Per-request opt-out. Returning true bypasses the limiter entirely. */
+  skip?: (req: Request) => boolean;
+  /** Derives the bucket key. Defaults to the client IP. */
+  keyGenerator?: (req: Request) => string;
+  /** Body of the 429 JSON response: `{ error: message }`. */
+  message?: string;
+}
+
+export type RateLimiter = RequestHandler & { reset: () => void };
+
+export function createRateLimiter(options: RateLimitOptions): RateLimiter {
+  const {
+    windowMs,
+    limit,
+    skipSuccessfulRequests = false,
+    skip,
+    keyGenerator = (req) => req.ip ?? 'unknown',
+    message = 'Too many requests, please try again later.',
+  } = options;
+
+  const buckets = new Map<string, Bucket>();
+
+  const middleware: RequestHandler = (req: Request, res: Response, next: NextFunction): void => {
+    if (skip?.(req)) {
+      next();
+      return;
+    }
+
+    const now = Date.now();
+    const key = keyGenerator(req);
+    let bucket = buckets.get(key);
+
+    // Start a fresh window if there's no bucket yet or the old one has expired.
+    if (!bucket || now >= bucket.resetAt) {
+      bucket = { count: 0, resetAt: now + windowMs };
+      buckets.set(key, bucket);
+    }
+
+    if (bucket.count >= limit) {
+      const retryAfterSec = Math.max(1, Math.ceil((bucket.resetAt - now) / 1000));
+      res.setHeader('Retry-After', String(retryAfterSec));
+      res.status(429).json({ error: message });
+      return;
+    }
+
+    bucket.count += 1;
+
+    // Roll the increment back once the response is known to be a success, so
+    // successful requests don't count toward the cap when configured.
+    if (skipSuccessfulRequests) {
+      const counted = bucket;
+      res.on('finish', () => {
+        if (res.statusCode < 400 && counted.count > 0) counted.count -= 1;
+      });
+    }
+
+    next();
+  };
+
+  (middleware as RateLimiter).reset = () => buckets.clear();
+  return middleware as RateLimiter;
+}
+
+// Jest sets NODE_ENV='test', which disables the shared limiters below so the
+// existing supertest suites (which fire many requests at one router) are
+// unaffected. The limiter itself is covered directly in rate-limit.test.ts.
+const limitingDisabled = process.env.NODE_ENV === 'test';
+
+// Strict: brute-force protection for the admin password endpoint. Only failed
+// logins count, so the real admin is never locked out by signing in normally.
+export const loginRateLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000,
+  limit: 10,
+  skipSuccessfulRequests: true,
+  skip: () => limitingDisabled,
+  message: 'Too many login attempts. Please wait a few minutes and try again.',
+});
+
+// Moderate: spam protection for the public endpoints that write to the DB and
+// trigger emails (registration, waiting list, leader applications, sign-in
+// links). Generous enough for a real family filling in forms, low enough to
+// stop a script blasting the inbox or the database.
+export const publicFormRateLimiter = createRateLimiter({
+  windowMs: 10 * 60 * 1000,
+  limit: 20,
+  skip: () => limitingDisabled,
+  message: 'Too many requests from this device. Please wait a little while and try again.',
+});

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -17,8 +17,14 @@ import { teamsRouter } from './routes/teams';
 import { publicConfigRouter } from './routes/public-config';
 import { registrationStatusRouter } from './routes/registration-status';
 import { waitlistRouter } from './routes/waitlist';
+import { loginRateLimiter, publicFormRateLimiter } from './middleware/rate-limit';
 
 const app = express();
+
+// Render terminates TLS at its proxy and forwards the real client IP in
+// X-Forwarded-For. Trusting the first hop lets the rate limiter key off the
+// actual visitor instead of lumping everyone behind the proxy into one bucket.
+app.set('trust proxy', 1);
 
 app.use(
   cors({
@@ -64,6 +70,15 @@ app.use((req, res, next) => {
   }
   next();
 });
+
+// Spam / brute-force protection. Mounted by path *before* the routers so they
+// run first. Strict limiter on the credential endpoint; a moderate limiter on
+// the public endpoints that write to the DB and send email.
+app.use('/admin/login', loginRateLimiter);
+app.use('/submit', publicFormRateLimiter);
+app.use('/waitlist', publicFormRateLimiter);
+app.use('/leaders/apply', publicFormRateLimiter);
+app.use('/request-link', publicFormRateLimiter);
 
 app.use(submitRouter);
 app.use(consentRouter);


### PR DESCRIPTION
Dependency-free fixed-window limiter (single Render instance, no Redis needed). Strict 10/15min on /admin/login counting only failed attempts; moderate 20/10min on the public DB+email endpoints (/submit, /waitlist, /leaders/apply, /request-link). Disabled under NODE_ENV=test. Adds trust proxy so buckets key off the real client IP behind Render.