### PR TITLE
Drop unused LEADER_PASSWORD_HASH env requirement

### DIFF
--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -66,7 +66,6 @@ export const envSchema = z.object({
     ),
   JWT_SECRET: z.string().min(32, 'JWT_SECRET must be at least 32 characters'),
   ADMIN_PASSWORD_HASH: z.string().min(1),
-  LEADER_PASSWORD_HASH: z.string().min(1),
   // Bcrypt hash of Neil's second-factor password for approve/reject. Generated
   // the same way as ADMIN_PASSWORD_HASH (`npm run hash:admin-password -- '<pw>'`).
   // The previous hardcoded literal in admin.ts has been removed and must be

--- a/render.yaml
+++ b/render.yaml
@@ -33,8 +33,6 @@ services:
         sync: false
       - key: ADMIN_PASSWORD_HASH
         sync: false
-      - key: LEADER_PASSWORD_HASH
-        sync: false
       - key: NEIL_PASSWORD_HASH
         sync: false
       - key: GMAIL_USER


### PR DESCRIPTION
It was required by the env schema (z.string().min(1)) but read by no route or service — only the schema and two test fixtures referenced it. A missing value crash-loops boot ('Invalid environment configuration: LEADER_PASSWORD_HASH Required'), which is exactly what blocked the live admin login after the var was removed from the Render dashboard: the env-var change triggered a redeploy of main that could not boot, so Render kept serving the previous build with the old admin hash.

Remove the requirement from env.ts and the render.yaml blueprint.